### PR TITLE
Add option for vscode flavour and use that to determine the window

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ sudo apt install -y wmctrl x11-utils bash
 
 ## Usage
 - Install the extension
-- Restart any single VSCode window
+- If you have VSCodium instead of VSCode you need to change `Glassit-linux: VSCode Flavour` in the settings to VSCodium
+- Restart any single VSCode/VSCodium window
 
 ## Settings
 
 Opacity defaults to `97%`, but can be set with the setting `Glassit-linux: Opacity` in VSCode's settings window. A restart of any single window is required for this setting to take effect.
+
+VSCode flavour defaults to `Visual Studio Code`, but if you are running VSCodium you can change this with `Glassit-linux: VSCode Flavour` in the settings window. A restart of any single window is required for this setting to take effect.
 
 ## Links
 - Repo: https://github.com/Fmstrat/glassit-linux

--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,8 @@ function activate(context) {
     if (!opacity) {
         opacity = 97;
     }
-    const cmd = `bash -c 'for W in $(wmctrl -l |grep "Visual Studio Code" |awk '"'"'{print $1}'"'"'); do xprop -id $W -format _NET_WM_WINDOW_OPACITY 32c -set _NET_WM_WINDOW_OPACITY $(printf 0x%x $((0xffffffff * ${opacity} / 100))); done'`;
+    let vscodeFlavour = vscode.workspace.getConfiguration("glassit-linux").get("vscode-flavour");
+    const cmd = `bash -c 'for W in $(wmctrl -l |grep "${vscodeFlavour}" |awk '"'"'{print $1}'"'"'); do xprop -id $W -format _NET_WM_WINDOW_OPACITY 32c -set _NET_WM_WINDOW_OPACITY $(printf 0x%x $((0xffffffff * ${opacity} / 100))); done'`;
     const terminal = vscode.window.createTerminal('glassit-linux');
     terminal.sendText(cmd);
     terminal.sendText(`exit`);

--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,7 @@ function activate(context) {
     if (!opacity) {
         opacity = 97;
     }
-    let vscodeFlavour = vscode.workspace.getConfiguration("glassit-linux").get("vscode-flavour");
+    let vscodeFlavour = vscode.workspace.getConfiguration("glassit-linux").get("VSCodeFlavour");
     const cmd = `bash -c 'for W in $(wmctrl -l |grep "${vscodeFlavour}" |awk '"'"'{print $1}'"'"'); do xprop -id $W -format _NET_WM_WINDOW_OPACITY 32c -set _NET_WM_WINDOW_OPACITY $(printf 0x%x $((0xffffffff * ${opacity} / 100))); done'`;
     const terminal = vscode.window.createTerminal('glassit-linux');
     terminal.sendText(cmd);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,15 @@
                         "scope": "window",
                         "description": "Set to the percentage you wish windows to be opaque (requires restart)",
                         "default": 97
+                    },
+                    "glassit-linux.vscode-flavour": {
+                        "type": "string",
+                        "scope": "window",
+                        "default": "Visual Studio Code",
+                        "enum": [
+                            "Visual Studio Code",
+                            "VSCodium"
+                        ]
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -35,14 +35,15 @@
                         "description": "Set to the percentage you wish windows to be opaque (requires restart)",
                         "default": 97
                     },
-                    "glassit-linux.vscode-flavour": {
+                    "glassit-linux.VSCodeFlavour": {
                         "type": "string",
                         "scope": "window",
                         "default": "Visual Studio Code",
                         "enum": [
                             "Visual Studio Code",
                             "VSCodium"
-                        ]
+                        ],
+                        "description": "Change this to VSCodium if this is what you are using (requires restart)"
                     }
                 }
             }


### PR DESCRIPTION
Hi, it would be nice to be able to use the extension with VSCodium. It would be nice to auto detect vscodeFlavour but I'm not familiar with such thing. Couldn't debug this locally but I don't see what could be wrong with the code.