### PR TITLE
Adds support for Code - OSS and VSCodium

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,7 @@ function activate(context) {
     if (!opacity) {
         opacity = 97;
     }
-    const cmd = `bash -c 'for W in $(wmctrl -l |grep "Visual Studio Code" |awk '"'"'{print $1}'"'"'); do xprop -id $W -format _NET_WM_WINDOW_OPACITY 32c -set _NET_WM_WINDOW_OPACITY $(printf 0x%x $((0xffffffff * ${opacity} / 100))); done'`;
+    const cmd = `bash -c 'for W in $(wmctrl -l |grep "Visual Studio Code\\|Code - OSS\\|VSCodium" |awk '"'"'{print $1}'"'"'); do xprop -id $W -format _NET_WM_WINDOW_OPACITY 32c -set _NET_WM_WINDOW_OPACITY $(printf 0x%x $((0xffffffff * ${opacity} / 100))); done'`;
     const terminal = vscode.window.createTerminal('glassit-linux');
     terminal.sendText(cmd);
     terminal.sendText(`exit`);


### PR DESCRIPTION
Because of multiple version available I added the support for 2 of them (Code - OSS and VSCodium, both tested on manjaro Xfce). 
I managed to make it work however by creating new extension using 'yo' (with the code copied from your repo) as npm had problem with direct copy of your repository (couldn't find a module). I'm commiting here just extension.js file so it shouldn't matter.